### PR TITLE
Add UI for fallback_formatter settings

### DIFF
--- a/fallback_formatter.admin.js
+++ b/fallback_formatter.admin.js
@@ -1,0 +1,49 @@
+(function ($) {
+
+Drupal.behaviors.formatterStatusStatus = {
+  attach: function (context, settings) {
+    $('.fallback-formatter-status-wrapper input.form-checkbox', context).once('fallback-formatter-status', function () {
+      var $checkbox = $(this);
+      // Retrieve the tabledrag row belonging to this filter.
+      var $row = $('#' + $checkbox.attr('id').replace(/-status$/, '-weight'), context).closest('tr');
+      // Retrieve the vertical tab belonging to this filter.
+      var tab = $('#' + $checkbox.attr('id').replace(/-status$/, '-settings'), context).data('verticalTab');
+      // Because the vertical tabs aren't currently working, just work on the
+      // fieldset itself for now.
+      var $fieldset = $('#' + $checkbox.attr('id').replace(/-status$/, '-settings'), context);
+
+      // Bind click handler to this checkbox to conditionally show and hide the
+      // filter's tableDrag row and vertical tab pane.
+      $checkbox.bind('click.filterUpdate', function () {
+        if ($checkbox.is(':checked')) {
+          $row.show();
+          $fieldset.show();
+          if (tab) {
+            tab.tabShow().updateSummary();
+          }
+        }
+        else {
+          $row.hide();
+          $fieldset.hide();
+          if (tab) {
+            tab.tabHide().updateSummary();
+          }
+        }
+        // Restripe table after toggling visibility of table row.
+        Drupal.tableDrag['fallback-formatter-order'].restripeTable();
+      });
+
+      // Attach summary for configurable filters (only for screen-readers).
+      if (tab) {
+        tab.fieldset.drupalSetSummary(function (tabContext) {
+          return $checkbox.is(':checked') ? Drupal.t('Enabled') : Drupal.t('Disabled');
+        });
+      }
+
+      // Trigger our bound click handler to update elements to initial state.
+      $checkbox.triggerHandler('click.filterUpdate');
+    });
+  }
+};
+
+})(jQuery);

--- a/fallback_formatter.module
+++ b/fallback_formatter.module
@@ -77,7 +77,18 @@ function fallback_formatter_field_formatter_settings_summary($field, $instance, 
       $summary[] = '<strong>' . t('Invalid formatter %name.', array('%name' => $formatters[$name]['label'])) . '</strong>';
     }
     else {
-      $summary[] = check_plain($formatters[$name]['label']);
+      $formatter_summary = check_plain($formatters[$name]['label']);
+
+      $function = $formatter['module'] . '_field_formatter_settings_summary';
+      if (function_exists($function)) {
+        $formatter_instance = _fallback_formatter_create_instance($instance, $view_mode, $name, $settings['formatters']);
+        $result = $function($field, $formatter_instance, $view_mode);
+        if (!empty($result)) {
+          $formatter_summary .= '<br><em>' . filter_xss($result) . '</em>';
+        }
+      }
+
+      $summary[] = $formatter_summary;
     }
   }
 
@@ -169,11 +180,7 @@ function fallback_formatter_field_formatter_settings_form($field, $instance, $vi
     if (function_exists($function)) {
       // Create a clone of the current instance variable with settings swapped
       // out.
-      $formatter_instance = $instance;
-      $formatter_instance['display'][$view_mode] = $formatter;
-      $formatter_instance['display'][$view_mode]['type'] = $name;
-      $formatter_instance['display'][$view_mode]['settings'] = isset($settings['formatters'][$name]['settings']) ? $settings['formatters'][$name]['settings'] : array();
-      $formatter_instance['display'][$view_mode]['settings'] += $formatter['settings'];
+      $formatter_instance = _fallback_formatter_create_instance($instance, $view_mode, $name, $settings['formatters']);
 
       $settings_form = $function($field, $formatter_instance, $view_mode, $form, $form_state);
       if (!empty($settings_form)) {
@@ -229,6 +236,16 @@ function fallback_formatter_field_formatter_view($entity_type, $entity, $field, 
   ksort($element);
 
   return $element;
+}
+
+function _fallback_formatter_create_instance(array $instance, $view_mode, $formatter_name, array $formatters) {
+  $formatter = field_info_formatter_types($formatter_name);
+  $clone = $instance;
+  $clone['display'][$view_mode] = $formatter;
+  $clone['display'][$view_mode]['type'] = $formatter_name;
+  $clone['display'][$view_mode]['settings'] = isset($formatters[$formatter_name]['settings']) ? $formatters[$formatter_name]['settings'] : array();
+  $clone['display'][$view_mode]['settings'] += $formatter['settings'];
+  return $clone;
 }
 
 function fallback_formatter_get_possibe_formatters($field_type) {

--- a/fallback_formatter.module
+++ b/fallback_formatter.module
@@ -99,9 +99,20 @@ function fallback_formatter_field_formatter_settings_form($field, $instance, $vi
   $element = array();
   $formatters = fallback_formatter_get_possibe_formatters($field['type']);
 
+  $element['#attached']['js'][] = drupal_get_path('module', 'fallback_formatter') . '/fallback_formatter.admin.js';
+
   $weights = array();
+  $current_weight = 0;
   foreach ($formatters as $name => $formatter) {
-    $weights[$name] = isset($settings['formatters'][$name]['weight']) ? $settings['formatters'][$name]['weight'] : (isset($formatter['weight']) ? $formatter['weight'] : 0);
+    if (isset($settings['formatters'][$name]['weight'])) {
+      $weights[$name] = $settings['formatters'][$name]['weight'];
+    }
+    elseif (isset($formatter['weight'])) {
+      $weights[$name] = $formatter['weight'];
+    }
+    elseif (empty($settings['formatters'])) {
+      $weights[$name] = $current_weight++;
+    }
   }
 
   $parents = array('fields', $field['field_name'], 'settings_edit_form', 'settings', 'formatters');
@@ -110,7 +121,7 @@ function fallback_formatter_field_formatter_settings_form($field, $instance, $vi
   $element['formatters']['status'] = array(
     '#type' => 'item',
     '#title' => t('Enabled formatters'),
-    '#prefix' => '<div id="fallback-formatter-status-wrapper">',
+    '#prefix' => '<div class="fallback-formatter-status-wrapper">',
     '#suffix' => '</div>',
   );
   foreach ($formatters as $name => $formatter) {
@@ -145,13 +156,13 @@ function fallback_formatter_field_formatter_settings_form($field, $instance, $vi
   }
 
   // Filter settings.
-  $element['formatter_settings_title'] = array(
+  /*$element['formatter_settings_title'] = array(
     '#type' => 'item',
     '#title' => t('Formatter settings'),
   );
   $element['formatter_settings'] = array(
     '#type' => 'vertical_tabs',
-  );
+  );*/
 
   foreach ($formatters as $name => $formatter) {
     $function = $formatter['module'] . '_field_formatter_settings_form';

--- a/fallback_formatter.module
+++ b/fallback_formatter.module
@@ -1,6 +1,17 @@
 <?php
 
 /**
+ * Implements hook_theme().
+ */
+function fallback_formatter_theme() {
+  return array(
+    'fallback_formatter_settings_order' => array(
+      'render element' => 'element',
+    ),
+  );
+}
+
+/**
  * Implements hook_field_formatter_info().
  */
 function fallback_formatter_field_formatter_info() {
@@ -55,16 +66,19 @@ function fallback_formatter_field_formatter_settings_summary($field, $instance, 
   $settings = $display['settings'];
   $formatters = field_info_formatter_types();
 
+  _fallback_formatter_prepare_formatters($field['type'], $settings['formatters']);
+  dpm($settings);
+
   $summary = array();
-  foreach ($settings['formatters'] as $formatter) {
-    if (!isset($formatters[$formatter['type']])) {
-      $summary[] = '<strong>' . t('Unknown formatter %name.', array('%name' => $formatter['type'])) . '</strong>';
+  foreach ($settings['formatters'] as $name => $formatter) {
+    if (!isset($formatters[$name])) {
+      $summary[] = '<strong>' . t('Unknown formatter %name.', array('%name' => $name)) . '</strong>';
     }
-    elseif (in_array($field['type'], $formatters[$formatter['type']]['field types'])) {
-      $summary[] = '<strong>' . t('Invalid formatter %name.', array('%name' => $formatter['type'])) . '</strong>';
+    elseif (!in_array($field['type'], $formatters[$name]['field types'])) {
+      $summary[] = '<strong>' . t('Invalid formatter %name.', array('%name' => $formatters[$name]['label'])) . '</strong>';
     }
     else {
-      $summary[] = check_plain($formatters[$formatter['type']]['label']);
+      $summary[] = check_plain($formatters[$name]['label']);
     }
   }
 
@@ -76,109 +90,96 @@ function fallback_formatter_field_formatter_settings_summary($field, $instance, 
   }
 }
 
-function fallback_formatter_get_possibe_formatters($field_type) {
-  $return = array();
-
-  foreach (field_info_formatter_types() as $formatter => $info) {
-    // The fallback formatter cannot be used as a fallback formatter.
-    if ($formatter == 'fallback') {
-      continue;
-    }
-    // Check that the field type is allowed for the formatter.
-    elseif (!in_array($field_type, $info['field types'])) {
-      continue;
-    }
-    // Formatters tagged as 'multiple' that render all items as one element
-    // instead of one element per item delta will fail fallback detection.
-    elseif (isset($info['behaviors']['multiple']) && $info['behaviors']['multiple'] == FIELD_BEHAVIOR_CUSTOM) {
-      continue;
-    }
-    else {
-      $return[$formatter] = $info;
-    }
-  }
-
-  return $return;
-}
-
 /**
- * Implements field_formatter_settings_form().
+ * Implements hook_field_formatter_settings_form().
  */
 function fallback_formatter_field_formatter_settings_form($field, $instance, $view_mode, $form, &$form_state) {
+  $display = $instance['display'][$view_mode];
+  $settings = $display['settings'];
+
+  $element = array();
   $formatters = fallback_formatter_get_possibe_formatters($field['type']);
 
-  //fields[field_test][settings_edit_form][settings][view_mode]
-
-  dpm($form);
-
-  $parents = array($field['field_name'], 'settings_edit_form', 'settings');
-
-  $rows = array();
-  foreach ($formatters as $id => $formatter) {
-    $row = array();
-    $row['data'] = array();
-    $row['data'][] = array('class' => array('entry-cross'));
-    $row['data'][] = array('data' => array(
-      '#type' => 'weight',
-      '#title' => t('Weight'),
-      '#title_display' => 'invisible',
-      '#default_value' => 0,
-      '#parents' => array_merge($parents, array('formatters', $id, 'weight')),
-      '#attributes' => array(
-        'class' => array('entry-order-weight'),
-      ),
-    ));
-    $row['data'][] = array('data' => array(
-      '#type' => 'checkbox',
-      '#title' => t('Enabled'),
-      '#title_display' => 'invisible',
-      '#default_value' => 1,
-      '#parents' => array_merge($parents, array('formatters', $id, 'enabled')),
-    ));
-    $row['data'][] = array('data' => check_plain($formatter['label']));
-    $row['class'][] = 'draggable';
-    $rows[$id] = $row;
+  $weights = array();
+  foreach ($formatters as $name => $formatter) {
+    $weights[$name] = isset($settings['formatters'][$name]['weight']) ? $settings['formatters'][$name]['weight'] : (isset($formatter['weight']) ? $formatter['weight'] : 0);
   }
 
-  $element['formatters'] = array(
-    '#theme' => 'table',
-    '#header' => array(
-      // We need two empty columns for the weight field and the cross.
-      array('data' => NULL, 'colspan' => 2),
-      t('Enabled'),
-      t('Formatter'),
-    ),
-    '#rows' => $rows,
-    '#empty' => t('No formatters available.'),
-    '#attributes' => array('id' => $field['field_name'] . '-fallback-formatters'),
-    //'#element_validate' => array('_test_validate'),
+  $parents = array('fields', $field['field_name'], 'settings_edit_form', 'settings', 'formatters');
+
+  // Filter status.
+  $element['formatters']['status'] = array(
+    '#type' => 'item',
+    '#title' => t('Enabled formatters'),
+    '#prefix' => '<div id="fallback-formatter-status-wrapper">',
+    '#suffix' => '</div>',
   );
-  drupal_add_tabledrag($field['field_name'] . '-fallback-formatters', 'order', 'sibling', 'entry-order-weight');
+  foreach ($formatters as $name => $formatter) {
+    $element['formatters']['status'][$name] = array(
+      '#type' => 'checkbox',
+      '#title' => $formatter['label'],
+      '#default_value' => !empty($settings['formatters'][$name]['status']),
+      '#parents' => array_merge($parents, array($name, 'status')),
+      '#weight' => $weights[$name],
+    );
+  }
+
+  // Filter order (tabledrag).
+  $element['formatters']['order'] = array(
+    '#type' => 'item',
+    '#title' => t('Formatter processing order'),
+    '#theme' => 'fallback_formatter_settings_order',
+  );
+  foreach ($formatters as $name => $formatter) {
+    $element['formatters']['order'][$name]['label'] = array(
+      '#markup' => $formatter['label'],
+    );
+    $element['formatters']['order'][$name]['weight'] = array(
+      '#type' => 'weight',
+      '#title' => t('Weight for @title', array('@title' => $formatter['label'])),
+      '#title_display' => 'invisible',
+      '#delta' => 50,
+      '#default_value' => $weights[$name],
+      '#parents' => array_merge($parents, array($name, 'weight')),
+    );
+    $element['formatters']['order'][$name]['#weight'] = $weights[$name];
+  }
+
+  // Filter settings.
+  $element['formatter_settings_title'] = array(
+    '#type' => 'item',
+    '#title' => t('Formatter settings'),
+  );
+  $element['formatter_settings'] = array(
+    '#type' => 'vertical_tabs',
+  );
+
+  foreach ($formatters as $name => $formatter) {
+    $function = $formatter['module'] . '_field_formatter_settings_form';
+    if (function_exists($function)) {
+      // Create a clone of the current instance variable with settings swapped
+      // out.
+      $formatter_instance = $instance;
+      $formatter_instance['display'][$view_mode] = $formatter;
+      $formatter_instance['display'][$view_mode]['type'] = $name;
+      $formatter_instance['display'][$view_mode]['settings'] = isset($settings['formatters'][$name]['settings']) ? $settings['formatters'][$name]['settings'] : array();
+      $formatter_instance['display'][$view_mode]['settings'] += $formatter['settings'];
+
+      $settings_form = $function($field, $formatter_instance, $view_mode, $form, $form_state);
+      if (!empty($settings_form)) {
+        $element['formatters']['settings'][$name] = array(
+          '#type' => 'fieldset',
+          '#title' => $formatter['label'],
+          '#parents' => array_merge($parents, array($name, 'settings')),
+          '#weight' => $weights[$name],
+          '#group' => 'formatter_settings',
+        );
+        $element['formatters']['settings'][$name] += $settings_form;
+      }
+    }
+  }
 
   return $element;
-}
-
-function fallback_formatter_sort_formatters($a, $b) {
-  $a_weight = (is_array($a) && isset($a['weight'])) ? $a['weight'] : 0;
-  $b_weight = (is_array($b) && isset($b['weight'])) ? $b['weight'] : 0;
-  return ($a_weight < $b_weight) ? -1 : 1;
-}
-
-function _fallback_formatter_prepare_formatters($field_type, array &$formatters) {
-  $allowed_formatters = fallback_formatter_get_possibe_formatters($field_type);
-
-  $formatters = array_intersect_key($formatters, $allowed_formatters);
-
-  foreach ($formatters as $formatter => $info) {
-    // Provide some default values.
-    $formatters[$formatter] += array('type' => $formatter, 'weight' => 0);
-    // Merge in defaults and settigns from hook_field_formatter_info().
-    $formatters[$formatter] += $allowed_formatters[$formatter];
-    $formatters[$formatter]['settings'] += $allowed_formatters[$formatter]['settings'];
-  }
-
-  // Sort by weight.
-  uasort($formatters, 'fallback_formatter_sort_formatters');
 }
 
 /**
@@ -218,4 +219,80 @@ function fallback_formatter_field_formatter_view($entity_type, $entity, $field, 
   ksort($element);
 
   return $element;
+}
+
+function fallback_formatter_get_possibe_formatters($field_type) {
+  $return = array();
+
+  foreach (field_info_formatter_types() as $formatter => $info) {
+    // The fallback formatter cannot be used as a fallback formatter.
+    if ($formatter == 'fallback') {
+      continue;
+    }
+    // Check that the field type is allowed for the formatter.
+    elseif (!in_array($field_type, $info['field types'])) {
+      continue;
+    }
+    // Formatters tagged as 'multiple' that render all items as one element
+    // instead of one element per item delta will fail fallback detection.
+    elseif (isset($info['behaviors']['multiple']) && $info['behaviors']['multiple'] == FIELD_BEHAVIOR_CUSTOM) {
+      continue;
+    }
+    else {
+      $return[$formatter] = $info;
+    }
+  }
+
+  return $return;
+}
+
+function _fallback_formatter_prepare_formatters($field_type, array &$formatters) {
+  $allowed_formatters = fallback_formatter_get_possibe_formatters($field_type);
+
+  $formatters = array_intersect_key($formatters, $allowed_formatters);
+
+  foreach ($formatters as $formatter => $info) {
+    // Remove disabled formatters.
+    if (isset($info['status']) && !$info['status']) {
+      unset($formatters[$formatter]);
+      continue;
+    }
+
+    // Provide some default values.
+    $formatters[$formatter] += array('type' => $formatter, 'weight' => 0);
+    // Merge in defaults and settigns from hook_field_formatter_info().
+    $formatters[$formatter] += $allowed_formatters[$formatter];
+    $formatters[$formatter]['settings'] += $allowed_formatters[$formatter]['settings'];
+  }
+
+  // Sort by weight.
+  uasort($formatters, 'fallback_formatter_sort_formatters');
+}
+
+function fallback_formatter_sort_formatters($a, $b) {
+  $a_weight = (is_array($a) && isset($a['weight'])) ? $a['weight'] : 0;
+  $b_weight = (is_array($b) && isset($b['weight'])) ? $b['weight'] : 0;
+  return ($a_weight < $b_weight) ? -1 : 1;
+}
+
+function theme_fallback_formatter_settings_order($variables) {
+  $element = $variables['element'];
+
+  // Fallback formatter order (tabledrag).
+  $rows = array();
+  foreach (element_children($element, TRUE) as $name) {
+    $element[$name]['weight']['#attributes']['class'][] = 'fallback-formatter-order-weight';
+    $rows[] = array(
+      'data' => array(
+        drupal_render($element[$name]['label']),
+        drupal_render($element[$name]['weight']),
+      ),
+      'class' => array('draggable'),
+    );
+  }
+  $output = drupal_render_children($element);
+  $output .= theme('table', array('rows' => $rows, 'attributes' => array('id' => 'fallback-formatter-order')));
+  drupal_add_tabledrag('fallback-formatter-order', 'order', 'sibling', 'fallback-formatter-order-weight', NULL, NULL, TRUE);
+
+  return $output;
 }

--- a/fallback_formatter.module
+++ b/fallback_formatter.module
@@ -67,7 +67,6 @@ function fallback_formatter_field_formatter_settings_summary($field, $instance, 
   $formatters = field_info_formatter_types();
 
   _fallback_formatter_prepare_formatters($field['type'], $settings['formatters']);
-  dpm($settings);
 
   $summary = array();
   foreach ($settings['formatters'] as $name => $formatter) {


### PR DESCRIPTION
- [x] Add fallback_formatter_field_formatter_settings_form
- [x] Add fallback_formatter_field_formatter_settings_summary
- [x] Fix vertical tabs inside formatter settings form

My initial thoughts:
- Needs to have a table select so the user can select which formatters are enabled
- Needs to have a tabledrag so the user can select the order of formatters
- Needs to expose the options for enabled formatters
