### PR TITLE
The formatter plugin is in options id, not type.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,7 @@ script:
   - cd $TRAVIS_BUILD_DIR/../drupal
   - ls -la $TRAVIS_BUILD_DIR/../drupal/sites/default
   # Run the tests
-  - php core/scripts/run-tests.sh --verbose --color --concurrency 4 --php `which php` --url http://localhost "fallback_formatter" | tee /tmp/test.txt
-  - TEST_EXIT=${PIPESTATUS[0]}
-  - echo $TEST_EXIT
+  - php core/scripts/run-tests.sh --verbose --color --concurrency 4 --php `which php` --url http://localhost "fallback_formatter" | tee /tmp/test.txt; TEST_EXIT=${PIPESTATUS[0]}; echo $TEST_EXIT
   # Check if we had fails in the run-tests.sh script
   # Exit with the inverted value, because if there are no fails found, it will exit with 1 and for us that\
   # is a good thing so invert it to 0. Travis has some issues with the exclamation mark in front so we have to fiddle a
@@ -83,9 +81,7 @@ script:
   - TEST_OUTPUT=$(! egrep -i "([0-9]+ fails)|(PHP Fatal error)|([0-9]+ exceptions)" /tmp/test.txt > /dev/null)$?
   - echo $TEST_OUTPUT
   - cd $TRAVIS_BUILD_DIR/../drupal/core
-  - ./vendor/bin/phpunit --verbose --debug ../modules/fallback_formatter/
-  - TEST_PHPUNIT=$?
-  - echo $TEST_PHPUNIT
+  - ./vendor/bin/phpunit --verbose --debug ../modules/fallback_formatter/; TEST_PHPUNIT=$?; echo $TEST_PHPUNIT
   # if the TEST_EXIT status is 0 AND the TEST_OUTPUT status is also 0 it means we succeeded, in all other cases we
   # failed.
   # Re-enable when trying to get CodeSniffer doesn't return a 403 anymore.

--- a/fallback_formatter.module
+++ b/fallback_formatter.module
@@ -8,6 +8,7 @@ function fallback_formatter_theme() {
   return array(
     'fallback_formatter_settings_order' => array(
       'render element' => 'element',
+      'function' => 'theme_fallback_formatter_settings_order',
     ),
   );
 }

--- a/src/Plugin/Field/FieldFormatter/FallbackFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FallbackFormatter.php
@@ -246,7 +246,7 @@ class FallbackFormatter extends FormatterBase {
     $options += array(
       'field_definition' => $this->fieldDefinition,
       'view_mode' => $this->viewMode,
-      'configuration' => array('type' => $options['type'], 'settings' => $options['settings']),
+      'configuration' => array('type' => $options['id'], 'settings' => $options['settings']),
     );
     return $this->formatterManager->getInstance($options);
   }

--- a/src/Plugin/Field/FieldFormatter/FallbackFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FallbackFormatter.php
@@ -274,7 +274,7 @@ class FallbackFormatter extends FormatterBase {
       }
 
       // Provide some default values.
-      $formatters[$formatter] += array('type' => $formatter, 'weight' => 0);
+      $formatters[$formatter] += array('weight' => 0);
       // Merge in defaults.
       $formatters[$formatter] += $allowed_formatters[$formatter];
       if (!empty($allowed_formatters[$formatter]['settings'])) {

--- a/src/Tests/FallbackFormatterTestCase.php
+++ b/src/Tests/FallbackFormatterTestCase.php
@@ -27,13 +27,13 @@ class FallbackFormatterTestCase extends WebTestBase {
     $this->contentType = $this->drupalCreateContentType();
 
     $field = entity_create('field_storage_config', array(
-      'name' => 'test_text',
+      'field_name' => 'test_text',
       'entity_type' => 'node',
       'type' => 'text',
     ));
     $field->save();
 
-    $instance = entity_create('field_instance_config', array(
+    $instance = entity_create('field_config', array(
       'field_storage' => $field,
       'bundle' => $this->contentType->id(),
     ));


### PR DESCRIPTION
Not sure why the tests didn't catch this, the first problem that I saw was that there were no settings (aka, it fell back to the default formatter which had no settings in my case).
